### PR TITLE
feat(backup): module backup complet - dump SQL, export CSV, tests unitaires

### DIFF
--- a/src/modules/backup.py
+++ b/src/modules/backup.py
@@ -1,0 +1,332 @@
+"""
+Module: [backup]
+Description: WMS database backup and CSV export module
+Responsible: ojvind
+"""
+
+import csv
+import hashlib
+import logging
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from src.interfaces import (
+    EXIT_CRITICAL,
+    EXIT_OK,
+    EXIT_UNKNOWN,
+    ModuleConfigError,
+    ModuleExecutionError,
+    build_result,
+)
+
+logger = logging.getLogger(__name__)
+
+MODULE_NAME = "[backup]"
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+def run(config: dict, target: str, **kwargs: Any) -> dict[str, Any]:
+    """Main entry point for the backup module.
+
+    Dispatches to backup_database() or export_table_csv() based on action.
+
+    Args:
+        config: Full config dict loaded from config.yaml.
+        target: Database name for backup, or table name for CSV export.
+        **kwargs: Must include action="backup_database" or action="export_table_csv".
+
+    Raises:
+        ModuleConfigError: If action is unknown or table_name is missing.
+        ModuleExecutionError: If execution fails unexpectedly.
+    """
+    logger.info("Starting %s on target: %s", MODULE_NAME, target)
+
+    action = kwargs.get("action", "backup_database")
+
+    try:
+        if action == "backup_database":
+            db_name = target or config.get("mysql", {}).get("database", "wms")
+            return backup_database(config, db_name)
+
+        elif action == "export_table_csv":
+            table_name = kwargs.get("table_name") or target
+            if not table_name:
+                raise ModuleConfigError("export_table_csv requires a table name (target or table_name kwarg)")
+            return export_table_csv(config, table_name)
+
+        else:
+            raise ModuleConfigError(f"Unknown action: {action}")
+
+    except ModuleConfigError:
+        raise
+    except Exception as e:
+        logger.error("%s execution failed: %s", MODULE_NAME, e)
+        raise ModuleExecutionError(str(e)) from e
+
+
+# ---------------------------------------------------------------------------
+# Internal helper
+# ---------------------------------------------------------------------------
+
+def _sha256(file_path: Path) -> str:
+    """Compute SHA256 checksum of a file."""
+    h = hashlib.sha256()
+    with open(file_path, "rb") as f:
+        for chunk in iter(lambda: f.read(65536), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# backup_database — Issue #8
+# ---------------------------------------------------------------------------
+
+def backup_database(config: dict, db_name: str) -> dict[str, Any]:
+    """Create a full MySQL dump via SSH and save it locally with SHA256.
+
+    Connects to the remote WMS-DB server via SSH (paramiko), executes
+    mysqldump, and writes the output to output/backups/<db>_YYYYMMDD_HHMMSS.sql.
+
+    Args:
+        config: Config dict with ssh and mysql sections.
+        db_name: Name of the database to dump.
+
+    Returns:
+        Standardized result dict.
+    """
+    try:
+        import paramiko  # type: ignore[import]
+    except ImportError:
+        return build_result(
+            module=MODULE_NAME,
+            function="backup_database",
+            status="UNKNOWN",
+            exit_code=EXIT_UNKNOWN,
+            target=db_name,
+            details={"error": "paramiko not installed. Run: pip install paramiko"},
+            message="paramiko is required for SSH-based backup",
+        )
+
+    ssh_conf = config.get("ssh", {})
+    mysql_conf = config.get("mysql", {})
+    output_dir = config.get("general", {}).get("output_dir", "./output")
+
+    host = ssh_conf.get("host", "")
+    port = int(ssh_conf.get("port", 22))
+    user = ssh_conf.get("user", "")
+    password = ssh_conf.get("password", "")
+    key_file = ssh_conf.get("key_file")
+    mysql_user = mysql_conf.get("user", "")
+    mysql_pass = mysql_conf.get("password", "")
+
+    if not host or not user:
+        return build_result(
+            module=MODULE_NAME,
+            function="backup_database",
+            status="UNKNOWN",
+            exit_code=EXIT_UNKNOWN,
+            target=db_name,
+            details={"error": "SSH host or user not configured"},
+            message="Missing SSH configuration",
+        )
+
+    client = paramiko.SSHClient()
+    client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+
+    try:
+        connect_kwargs: dict[str, Any] = {"hostname": host, "port": port, "username": user}
+        if key_file:
+            connect_kwargs["key_filename"] = key_file
+        else:
+            connect_kwargs["password"] = password
+
+        client.connect(**connect_kwargs)
+        logger.info("SSH connected to %s", host)
+
+        # Build mysqldump command (password via env to avoid shell history)
+        dump_cmd = (
+            f"MYSQL_PWD='{mysql_pass}' mysqldump -u {mysql_user} --databases {db_name}"
+        )
+        _, stdout, stderr = client.exec_command(dump_cmd)
+        dump_data = stdout.read()
+        err = stderr.read().decode("utf-8", errors="replace").strip()
+
+        if not dump_data:
+            logger.error("mysqldump produced no output: %s", err)
+            return build_result(
+                module=MODULE_NAME,
+                function="backup_database",
+                status="CRITICAL",
+                exit_code=EXIT_CRITICAL,
+                target=db_name,
+                details={"error": err or "Empty dump output"},
+                message=f"Backup failed for {db_name}: no data received",
+            )
+
+        # Count tables from the dump (rough estimate via CREATE TABLE lines)
+        table_count = dump_data.count(b"CREATE TABLE")
+
+        # Save locally
+        backup_dir = Path(output_dir) / "backups"
+        backup_dir.mkdir(parents=True, exist_ok=True)
+        ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+        sql_path = backup_dir / f"{db_name}_{ts}.sql"
+
+        sql_path.write_bytes(dump_data)
+        checksum = _sha256(sql_path)
+        size_bytes = sql_path.stat().st_size
+
+        logger.info("Backup saved to %s (%d bytes)", sql_path, size_bytes)
+
+        return build_result(
+            module=MODULE_NAME,
+            function="backup_database",
+            status="OK",
+            exit_code=EXIT_OK,
+            target=db_name,
+            details={
+                "file": str(sql_path),
+                "size_bytes": size_bytes,
+                "sha256": checksum,
+                "table_count": table_count,
+            },
+            message=f"Backup OK: {db_name} → {sql_path.name} ({size_bytes} bytes, {table_count} tables)",
+        )
+
+    except Exception as e:
+        logger.error("backup_database failed: %s", e)
+        return build_result(
+            module=MODULE_NAME,
+            function="backup_database",
+            status="CRITICAL",
+            exit_code=EXIT_CRITICAL,
+            target=db_name,
+            details={"error": str(e)},
+            message=f"Backup failed: {e}",
+        )
+
+    finally:
+        client.close()
+
+
+# ---------------------------------------------------------------------------
+# export_table_csv — Issue #9
+# ---------------------------------------------------------------------------
+
+def export_table_csv(config: dict, table_name: str) -> dict[str, Any]:
+    """Export a MySQL table to a CSV file with SHA256.
+
+    Connects directly to MySQL, executes SELECT * FROM <table_name>,
+    and writes results to output/backups/<table>_YYYYMMDD_HHMMSS.csv.
+
+    Args:
+        config: Config dict with mysql section.
+        table_name: Name of the table to export.
+
+    Returns:
+        Standardized result dict.
+    """
+    try:
+        import mysql.connector  # type: ignore[import]
+    except ImportError:
+        return build_result(
+            module=MODULE_NAME,
+            function="export_table_csv",
+            status="UNKNOWN",
+            exit_code=EXIT_UNKNOWN,
+            target=table_name,
+            details={"error": "mysql-connector-python not installed. Run: pip install mysql-connector-python"},
+            message="mysql-connector-python is required for CSV export",
+        )
+
+    mysql_conf = config.get("mysql", {})
+    output_dir = config.get("general", {}).get("output_dir", "./output")
+
+    host = mysql_conf.get("host", "")
+    port = int(mysql_conf.get("port", 3306))
+    user = mysql_conf.get("user", "")
+    password = mysql_conf.get("password", "")
+    database = mysql_conf.get("database", "")
+
+    if not host or not user or not database:
+        return build_result(
+            module=MODULE_NAME,
+            function="export_table_csv",
+            status="UNKNOWN",
+            exit_code=EXIT_UNKNOWN,
+            target=table_name,
+            details={"error": "MySQL host, user or database not configured"},
+            message="Missing MySQL configuration",
+        )
+
+    conn = None
+    cursor = None
+    try:
+        conn = mysql.connector.connect(
+            host=host,
+            port=port,
+            user=user,
+            password=password,
+            database=database,
+        )
+        cursor = conn.cursor()
+        logger.info("MySQL connected to %s/%s", host, database)
+
+        cursor.execute(f"SELECT * FROM `{table_name}`")  # noqa: S608
+        rows = cursor.fetchall()
+        columns = [desc[0] for desc in cursor.description]
+
+        # Save CSV
+        backup_dir = Path(output_dir) / "backups"
+        backup_dir.mkdir(parents=True, exist_ok=True)
+        ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+        csv_path = backup_dir / f"{table_name}_{ts}.csv"
+
+        with open(csv_path, "w", newline="", encoding="utf-8") as f:
+            writer = csv.writer(f)
+            writer.writerow(columns)
+            writer.writerows(rows)
+
+        checksum = _sha256(csv_path)
+        size_bytes = csv_path.stat().st_size
+        row_count = len(rows)
+
+        logger.info("CSV export saved to %s (%d rows)", csv_path, row_count)
+
+        return build_result(
+            module=MODULE_NAME,
+            function="export_table_csv",
+            status="OK",
+            exit_code=EXIT_OK,
+            target=table_name,
+            details={
+                "file": str(csv_path),
+                "columns": columns,
+                "row_count": row_count,
+                "size_bytes": size_bytes,
+                "sha256": checksum,
+            },
+            message=f"Export OK: {table_name} → {csv_path.name} ({row_count} rows)",
+        )
+
+    except Exception as e:
+        logger.error("export_table_csv failed: %s", e)
+        return build_result(
+            module=MODULE_NAME,
+            function="export_table_csv",
+            status="CRITICAL",
+            exit_code=EXIT_CRITICAL,
+            target=table_name,
+            details={"error": str(e)},
+            message=f"CSV export failed: {e}",
+        )
+
+    finally:
+        if cursor:
+            cursor.close()
+        if conn:
+            conn.close()

--- a/src/modules/backup.py
+++ b/src/modules/backup.py
@@ -278,6 +278,8 @@ def export_table_csv(config: dict, table_name: str) -> dict[str, Any]:
 
         cursor.execute(f"SELECT * FROM `{table_name}`")  # noqa: S608
         rows = cursor.fetchall()
+        if cursor.description is None:
+            raise RuntimeError(f"No description returned for table {table_name!r}")
         columns = [desc[0] for desc in cursor.description]
 
         # Save CSV

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -9,9 +9,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from src.interfaces import EXIT_CRITICAL, EXIT_OK, ModuleConfigError
 from src.modules.backup import _sha256, backup_database, export_table_csv, run
-from src.interfaces import EXIT_OK, EXIT_CRITICAL, EXIT_UNKNOWN, ModuleConfigError
-
 
 # ---------------------------------------------------------------------------
 # Config fixture

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -1,0 +1,211 @@
+"""
+Tests unitaires – Module backup
+Responsable: ojvind
+"""
+
+import hashlib
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.modules.backup import _sha256, backup_database, export_table_csv, run
+from src.interfaces import EXIT_OK, EXIT_CRITICAL, EXIT_UNKNOWN, ModuleConfigError
+
+
+# ---------------------------------------------------------------------------
+# Config fixture
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def config(tmp_path: Path) -> dict:
+    return {
+        "general": {"output_dir": str(tmp_path / "output"), "log_level": "INFO"},
+        "ssh": {
+            "host": "192.168.10.21",
+            "port": 22,
+            "user": "ntl",
+            "password": "secret",
+        },
+        "mysql": {
+            "host": "192.168.10.21",
+            "port": 3306,
+            "user": "ntl_user",
+            "password": "dbpass",
+            "database": "wms",
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Test 1 – backup_database crée un fichier .sql avec SHA256
+# ---------------------------------------------------------------------------
+
+class TestBackupDatabase:
+    def test_creates_sql_file_with_sha256(self, config: dict, tmp_path: Path):
+        """Le fichier .sql est créé localement et son SHA256 est renvoyé."""
+        fake_dump = b"-- MySQL dump\nCREATE TABLE orders (\n);\nCREATE TABLE shipments (\n);\n"
+
+        mock_stdout = MagicMock()
+        mock_stdout.read.return_value = fake_dump
+        mock_stderr = MagicMock()
+        mock_stderr.read.return_value = b""
+
+        with patch("paramiko.SSHClient") as MockSSH:
+            mock_client = MockSSH.return_value
+            mock_client.exec_command.return_value = (None, mock_stdout, mock_stderr)
+
+            result = backup_database(config, "wms")
+
+        assert result["status"] == "OK"
+        assert result["exit_code"] == EXIT_OK
+
+        saved_path = Path(result["details"]["file"])
+        assert saved_path.exists()
+        assert saved_path.suffix == ".sql"
+        assert saved_path.read_bytes() == fake_dump
+
+        expected_sha = hashlib.sha256(fake_dump).hexdigest()
+        assert result["details"]["sha256"] == expected_sha
+
+    def test_table_count_reported(self, config: dict):
+        """Le nombre de tables est compté via CREATE TABLE dans le dump."""
+        fake_dump = b"CREATE TABLE a ();\nCREATE TABLE b ();\nCREATE TABLE c ();\n"
+
+        mock_stdout = MagicMock()
+        mock_stdout.read.return_value = fake_dump
+        mock_stderr = MagicMock()
+        mock_stderr.read.return_value = b""
+
+        with patch("paramiko.SSHClient") as MockSSH:
+            mock_client = MockSSH.return_value
+            mock_client.exec_command.return_value = (None, mock_stdout, mock_stderr)
+
+            result = backup_database(config, "wms")
+
+        assert result["details"]["table_count"] == 3
+
+
+# ---------------------------------------------------------------------------
+# Test 2 – Calcul SHA256 correct
+# ---------------------------------------------------------------------------
+
+class TestSha256:
+    def test_sha256_matches_known_value(self, tmp_path: Path):
+        """_sha256 renvoie le bon hash pour un contenu connu."""
+        data = b"NTL-SysToolbox backup integrity check"
+        f = tmp_path / "test.bin"
+        f.write_bytes(data)
+
+        expected = hashlib.sha256(data).hexdigest()
+        assert _sha256(f) == expected
+
+    def test_sha256_differs_for_different_content(self, tmp_path: Path):
+        """Deux fichiers différents produisent des hashes différents."""
+        f1 = tmp_path / "a.bin"
+        f2 = tmp_path / "b.bin"
+        f1.write_bytes(b"content-one")
+        f2.write_bytes(b"content-two")
+
+        assert _sha256(f1) != _sha256(f2)
+
+
+# ---------------------------------------------------------------------------
+# Test 3 – Échec SSH → statut CRITICAL
+# ---------------------------------------------------------------------------
+
+class TestSshFailure:
+    def test_ssh_connection_error_returns_critical(self, config: dict):
+        """Une erreur SSH retourne status CRITICAL (pas de crash)."""
+        with patch("paramiko.SSHClient") as MockSSH:
+            mock_client = MockSSH.return_value
+            mock_client.connect.side_effect = Exception("Connection refused")
+
+            result = backup_database(config, "wms")
+
+        assert result["status"] == "CRITICAL"
+        assert result["exit_code"] == EXIT_CRITICAL
+        assert "error" in result["details"]
+
+    def test_empty_dump_returns_critical(self, config: dict):
+        """Un dump vide (mysqldump sans données) retourne CRITICAL."""
+        mock_stdout = MagicMock()
+        mock_stdout.read.return_value = b""
+        mock_stderr = MagicMock()
+        mock_stderr.read.return_value = b"Access denied"
+
+        with patch("paramiko.SSHClient") as MockSSH:
+            mock_client = MockSSH.return_value
+            mock_client.exec_command.return_value = (None, mock_stdout, mock_stderr)
+
+            result = backup_database(config, "wms")
+
+        assert result["status"] == "CRITICAL"
+        assert result["exit_code"] == EXIT_CRITICAL
+
+
+# ---------------------------------------------------------------------------
+# Test 4 – export_table_csv contient les bonnes colonnes et lignes
+# ---------------------------------------------------------------------------
+
+class TestExportTableCsv:
+    def test_csv_contains_correct_columns_and_rows(self, config: dict, tmp_path: Path):
+        """Le CSV exporté contient les bons en-têtes et toutes les lignes."""
+        fake_rows = [
+            (1, "ORD-001", "Lens", "2026-01-10"),
+            (2, "ORD-002", "Arras", "2026-01-11"),
+        ]
+        fake_columns = [("id",), ("order_ref",), ("warehouse",), ("date",)]
+
+        mock_cursor = MagicMock()
+        mock_cursor.fetchall.return_value = fake_rows
+        mock_cursor.description = fake_columns
+
+        mock_conn = MagicMock()
+        mock_conn.cursor.return_value = mock_cursor
+
+        with patch("mysql.connector.connect", return_value=mock_conn):
+            result = export_table_csv(config, "orders")
+
+        assert result["status"] == "OK"
+        assert result["exit_code"] == EXIT_OK
+        assert result["details"]["row_count"] == 2
+        assert result["details"]["columns"] == ["id", "order_ref", "warehouse", "date"]
+
+        # Verify CSV file on disk
+        csv_path = Path(result["details"]["file"])
+        assert csv_path.exists()
+        lines = csv_path.read_text(encoding="utf-8").splitlines()
+        assert lines[0] == "id,order_ref,warehouse,date"
+        assert len(lines) == 3  # header + 2 rows
+
+    def test_csv_sha256_is_present(self, config: dict):
+        """Le SHA256 du fichier CSV est inclus dans le résultat."""
+        mock_cursor = MagicMock()
+        mock_cursor.fetchall.return_value = [(1, "data")]
+        mock_cursor.description = [("id",), ("value",)]
+
+        mock_conn = MagicMock()
+        mock_conn.cursor.return_value = mock_cursor
+
+        with patch("mysql.connector.connect", return_value=mock_conn):
+            result = export_table_csv(config, "shipments")
+
+        assert "sha256" in result["details"]
+        assert len(result["details"]["sha256"]) == 64  # SHA256 hex = 64 chars
+
+
+# ---------------------------------------------------------------------------
+# Test 5 – Action invalide → ModuleConfigError
+# ---------------------------------------------------------------------------
+
+class TestRunDispatcher:
+    def test_invalid_action_raises_module_config_error(self, config: dict):
+        """Une action inconnue lève ModuleConfigError, sans crash silencieux."""
+        with pytest.raises(ModuleConfigError, match="Unknown action"):
+            run(config, "wms", action="nonexistent_action")
+
+    def test_export_without_table_raises_module_config_error(self, config: dict):
+        """export_table_csv sans nom de table lève ModuleConfigError."""
+        with pytest.raises(ModuleConfigError, match="table name"):
+            run(config, "", action="export_table_csv")


### PR DESCRIPTION
## Résumé

Ferme les issues #8, #9 et #24.

- `src/modules/backup.py` : implémentation complète du module backup
  - `backup_database()` : connexion SSH (paramiko), exécution mysqldump à distance, sauvegarde `.sql` horodatée avec SHA256
  - `export_table_csv()` : connexion MySQL directe, export table → CSV avec en-têtes et SHA256
  - `run()` : dispatcher vers les deux actions
- `tests/test_backup.py` : 10 tests unitaires (mocks, pas dinfrastructure réelle)
  - Création fichier .sql avec SHA256 correct
  - Comptage des tables depuis le dump
  - Correction et unicité du SHA256
  - Échec SSH / dump vide → statut CRITICAL
  - Colonnes et lignes CSV conformes
  - SHA256 CSV présent et valide
  - Action invalide → `ModuleConfigError`
  - Export sans nom de table → `ModuleConfigError`

## Plan de test

- [ ] `make test` passe (10/10 tests)
- [ ] `backup_database()` testé avec mock SSH
- [ ] `export_table_csv()` testé avec mock MySQL
- [ ] Gestion derreurs SSH et MySQL vérifiée
- [ ] SHA256 vérifié sur fichier réel

🤖 Generated with [Claude Code](https://claude.com/claude-code)